### PR TITLE
use API-TOKEN instead of simple bearer token

### DIFF
--- a/seeweb/seeweb.go
+++ b/seeweb/seeweb.go
@@ -115,7 +115,7 @@ func (c *Client) newRequest(method, url string, body interface{}, options ...Req
 			}
 		}
 	}
-	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.Config.Token))
+	req.Header.Add("X-APITOKEN", c.Config.Token)
 	req.Header.Add("Content-Type", "application/json")
 
 	if c.Config.UserAgent != "" {


### PR DESCRIPTION
On branch use-API-TOKEN-instead-of-bearer-token
Changes to be committed:
	modified:   seeweb/seeweb.go